### PR TITLE
robustness(avoid readSocket to block infinitely)

### DIFF
--- a/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
@@ -98,6 +98,7 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
     private static final int HTTP_PROTOCOL_VERSION_MAJOR = 1;
     private static final int HTTP_PROTOCOL_VERSION_MINOR = 1;
     private static final int CONNECTION_TIMEOUT = 60000;
+    private static final int SOCKET_TIMEOUT = 60000;
 
     /**
      * The class logger
@@ -458,6 +459,7 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
 
             final Builder requestConfigurationBuilder = RequestConfig.custom();
             requestConfigurationBuilder.setConnectionRequestTimeout(CONNECTION_TIMEOUT);
+            requestConfigurationBuilder.setSocketTimeout(SOCKET_TIMEOUT);
             requestConfigurationBuilder.setRedirectsEnabled(request.isRedirect());
 
             final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();


### PR DESCRIPTION
HTTPClient uses readSocket as part of the connection and it is a blocking method. It may happen that the readSocket is stuck and taking a lot of time making the connector executor thread uninterruptable by the Engine: the connector executor timeout will have not effect.

Without any socket timeout specified in the request builder, the JVM will handle the timeout using OS default config which can be really long. This meand that the connector executor pool can be clogged in no time and the only solution is to restart the server which is not robust.